### PR TITLE
docs: adding missing `await`

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ export default defineEventHandler(async (event) => {
     required: z.boolean()
   }))
 
-  const params = zh.useValidatedParams(event, {
+  const params = await zh.useValidatedParams(event, {
     id: z.number()
   })
 })


### PR DESCRIPTION
Hey there, love this package! Perfect for small projects where you don't want to load TRPC but need a little more typesafety in API routes.

Just discovered this missing `await` at `useValidatedParams`.