### PR TITLE
feat: add parse options

### DIFF
--- a/src/parsers.ts
+++ b/src/parsers.ts
@@ -28,6 +28,8 @@ function createBadRequest(error: any) {
   })
 }
 
+export type ParseOptions = Partial<z.ParseParams>
+
 /**
  * Parse and validate request query from event handler. Throws an error if validation fails.
  * @param event - A H3 event object.
@@ -36,11 +38,12 @@ function createBadRequest(error: any) {
 export async function useValidatedQuery<T extends Schema | z.ZodRawShape>(
   event: H3Event,
   schema: T,
+  parseOptions?: ParseOptions,
 ): Promise<ParsedData<T>> {
   try {
     const query = getQuery(event)
     const finalSchema = schema instanceof z.ZodType ? schema : z.object(schema)
-    const parsed = await finalSchema.parseAsync(query)
+    const parsed = await finalSchema.parseAsync(query, parseOptions)
     return parsed
   }
   catch (error) {
@@ -62,10 +65,11 @@ type SafeParsedData<T extends Schema | z.ZodRawShape> = T extends Schema
 export function useSafeValidatedQuery<T extends Schema | z.ZodRawShape>(
   event: H3Event,
   schema: T,
+  parseOptions?: ParseOptions,
 ): Promise<SafeParsedData<T>> {
   const query = getQuery(event)
   const finalSchema = schema instanceof z.ZodType ? schema : z.object(schema)
-  return finalSchema.safeParseAsync(query) as Promise<SafeParsedData<T>>
+  return finalSchema.safeParseAsync(query, parseOptions) as Promise<SafeParsedData<T>>
 }
 
 /**
@@ -76,11 +80,12 @@ export function useSafeValidatedQuery<T extends Schema | z.ZodRawShape>(
 export async function useValidatedBody<T extends Schema | z.ZodRawShape>(
   event: H3Event,
   schema: T,
+  parseOptions?: ParseOptions,
 ): Promise<ParsedData<T>> {
   try {
     const body = await readBody(event)
     const finalSchema = schema instanceof z.ZodType ? schema : z.object(schema)
-    const parsed = await finalSchema.parseAsync(body)
+    const parsed = await finalSchema.parseAsync(body, parseOptions)
     return parsed
   }
   catch (error) {
@@ -96,10 +101,11 @@ export async function useValidatedBody<T extends Schema | z.ZodRawShape>(
 export async function useSafeValidatedBody<T extends Schema | z.ZodRawShape>(
   event: H3Event,
   schema: T,
+  parseOptions?: ParseOptions,
 ): Promise<SafeParsedData<T>> {
   const body = await readBody(event)
   const finalSchema = schema instanceof z.ZodType ? schema : z.object(schema)
-  return finalSchema.safeParseAsync(body) as Promise<SafeParsedData<T>>
+  return finalSchema.safeParseAsync(body, parseOptions) as Promise<SafeParsedData<T>>
 }
 
 /**
@@ -110,11 +116,12 @@ export async function useSafeValidatedBody<T extends Schema | z.ZodRawShape>(
 export function useValidatedParams<T extends Schema | z.ZodRawShape>(
   event: H3Event,
   schema: T,
+  parseOptions?: ParseOptions,
 ): Promise<ParsedData<T>> {
   try {
     const params = getRouterParams(event)
     const finalSchema = schema instanceof z.ZodType ? schema : z.object(schema)
-    return finalSchema.parseAsync(params)
+    return finalSchema.parseAsync(params, parseOptions)
   }
   catch (error) {
     throw createBadRequest(error)
@@ -129,10 +136,11 @@ export function useValidatedParams<T extends Schema | z.ZodRawShape>(
 export function useSafeValidatedParams<T extends Schema | z.ZodRawShape>(
   event: H3Event,
   schema: T,
+  parseOptions?: ParseOptions,
 ): Promise<SafeParsedData<T>> {
   const params = getRouterParams(event)
   const finalSchema = schema instanceof z.ZodType ? schema : z.object(schema)
-  return finalSchema.safeParseAsync(params) as Promise<SafeParsedData<T>>
+  return finalSchema.safeParseAsync(params, parseOptions) as Promise<SafeParsedData<T>>
 }
 
 export {


### PR DESCRIPTION
Zod parse functions have a 2nd argument that lets you customize error messages, etc.

This PR will allow you to pass zod parse options as a 3rd argument to all of the h3-zod functions. Here's an example of [customizing an error message](https://github.com/colinhacks/zod/blob/master/ERROR_HANDLING.md#customizing-errors-with-zoderrormap):

```ts
const myErrorMap: z.ZodErrorMap = (issue, ctx) => {
  if (issue.code === z.ZodIssueCode.invalid_type) {
    if (issue.expected === "string") {
      return { message: "bad type!" };
    }
  }
  if (issue.code === z.ZodIssueCode.custom) {
    return { message: `less-than-${(issue.params || {}).minimum}` };
  }
  return { message: ctx.defaultError };
}

export default defineEventHandler(async (event) => {
  const body = await zh.useSafeValidatedBody(event, z.object({...}), { errorMap: myErrorMap })

  if (!params.success) {
    // params.error
  }
})
```