### PR TITLE
fix: catch error in useValidatedParams

### DIFF
--- a/src/parsers.ts
+++ b/src/parsers.ts
@@ -113,7 +113,7 @@ export async function useSafeValidatedBody<T extends Schema | z.ZodRawShape>(
  * @param event - A H3 event object.
  * @param schema - A Zod object shape or object schema to validate.
  */
-export function useValidatedParams<T extends Schema | z.ZodRawShape>(
+export async function useValidatedParams<T extends Schema | z.ZodRawShape>(
   event: H3Event,
   schema: T,
   parseOptions?: ParseOptions,
@@ -121,7 +121,8 @@ export function useValidatedParams<T extends Schema | z.ZodRawShape>(
   try {
     const params = getRouterParams(event)
     const finalSchema = schema instanceof z.ZodType ? schema : z.object(schema)
-    return finalSchema.parseAsync(params, parseOptions)
+    const parsed = await finalSchema.parseAsync(params, parseOptions)
+    return parsed
   }
   catch (error) {
     throw createBadRequest(error)


### PR DESCRIPTION
Hello,

I'm using this package for a project and behavior between useValidatedQuery is not the same as useValidatedParams.

In fact, when using useValidatedParams, I receive a 500 status code and on the server, this error is throw:

```
[nitro] [request error] [unhandled] [
  {
    "validation": "email",
    "code": "invalid_string",
    "message": "Invalid email",
    "path": [
      "id"
    ]
  }
]
  at get error [as error] (/C:/Users/esoubiran/dev/barbapapazes/playground-api.esteban-soubiran.site/node_modules/.pnpm/zod@3.21.4/node_modules/zod/lib/index.mjs:537:31)
  at ZodObject.parseAsync (/C:/Users/esoubiran/dev/barbapapazes/playground-api.esteban-soubiran.site/node_modules/.pnpm/zod@3.21.4/node_modules/zod/lib/index.mjs:659:22)
  at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
  at async Object.handler (/C:/Users/esoubiran/dev/barbapapazes/playground-api.esteban-soubiran.site/node_modules/.pnpm/h3@1.7.1/node_modules/h3/dist/index.mjs:1284:19)
  at async Server.toNodeHandle (/C:/Users/esoubiran/dev/barbapapazes/playground-api.esteban-soubiran.site/node_modules/.pnpm/h3@1.7.1/node_modules/h3/dist/index.mjs:1359:7)
```

This PR solve this issue.